### PR TITLE
Remove the breadcrumb title spacing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Usage
 This helper allows you to add breadcrumbs and is the equivalent of the `page-title` helper but for breadcrumbs.
 
 #### Positional argument(s)
-Positional arguments are used as the title for the breadcrumb. Multiple positional arguments will be combined into a single title (separated by spaces). 
+Positional arguments are used as the title for the breadcrumb. Multiple positional arguments will be combined into a single title. 
 
 ```hbs
 {{breadcrumb "Home"}}
 {{! "Home" }}
 
-{{breadcrumb "Hottest JS framework 🔥:" this.hottestFramework }}
+{{breadcrumb "Hottest JS framework 🔥: " this.hottestFramework}}
 {{! "Hottest JS framework 🔥: Ember" }}
 ```
 > The title can be accessed with the `title` property of the breadcrumb object.

--- a/addon/helpers/breadcrumb.js
+++ b/addon/helpers/breadcrumb.js
@@ -11,7 +11,7 @@ export default class BreadcrumbHelper extends Helper {
   }
 
   compute(breadcrumbTitleParts, optionalData) {
-    let breadcrumbTitle = breadcrumbTitleParts.join(' ');
+    let breadcrumbTitle = breadcrumbTitleParts.join('');
 
     let breadcrumbData = {
       data: optionalData,

--- a/tests/dummy/app/templates/foo/bar.hbs
+++ b/tests/dummy/app/templates/foo/bar.hbs
@@ -1,5 +1,5 @@
 {{page-title "Bar"}}
-{{breadcrumb "Bar:" this.number route="foo.bar"}}
+{{breadcrumb "Bar: " this.number route="foo.bar"}}
 {{outlet}}
 
 <button type="button" {{on "click" this.getRandomNumber}}>Random</button>

--- a/tests/dummy/app/templates/foo/bar/baz.hbs
+++ b/tests/dummy/app/templates/foo/bar/baz.hbs
@@ -1,3 +1,3 @@
 {{page-title "Baz"}}
-{{breadcrumb "Baz:" this.model route="foo.bar.baz"}}
+{{breadcrumb "Baz: " this.model route="foo.bar.baz"}}
 {{outlet}}

--- a/tests/integration/helpers/breadcrumb-test.js
+++ b/tests/integration/helpers/breadcrumb-test.js
@@ -28,7 +28,7 @@ module('Integration | Helper | breadcrumb', function (hooks) {
         {{/each}}
       </ol>
 
-      {{breadcrumb "foo" "bar" "baz"}}
+      {{breadcrumb "foo" " bar " "baz"}}
     `);
 
     assert.dom('[data-test-breadcrumb-item]').hasText('foo bar baz');


### PR DESCRIPTION
This removes the space between each breadcrumb title part when passing multiple positional arguments.

This is a better default since spaces can be added very easily but to "remove" them the user has to use the `{{concat}}` helper. This also makes it more consistent with how the `{{concat}}` and `{{page-title}}` helpers works.