### PR TITLE
Use namespaced service injections

### DIFF
--- a/addon/helpers/breadcrumb.js
+++ b/addon/helpers/breadcrumb.js
@@ -2,7 +2,7 @@ import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
 export default class BreadcrumbHelper extends Helper {
-  @service('breadcrumbs') breadcrumbsService;
+  @service('ember-breadcrumb-trail@breadcrumbs') breadcrumbsService;
 
   breadcrumbId = null;
 

--- a/addon/helpers/breadcrumbs.js
+++ b/addon/helpers/breadcrumbs.js
@@ -2,7 +2,7 @@ import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
 export default class BreadcrumbsHelper extends Helper {
-  @service('breadcrumbs') breadcrumbsService;
+  @service('ember-breadcrumb-trail@breadcrumbs') breadcrumbsService;
 
   compute() {
     return this.breadcrumbsService.items;

--- a/app/services/breadcrumbs.js
+++ b/app/services/breadcrumbs.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-breadcrumb-trail/services/breadcrumbs';

--- a/tests/dummy/app/routes/foo/bar/baz.js
+++ b/tests/dummy/app/routes/foo/bar/baz.js
@@ -1,9 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 
 export default class FooBarBazRoute extends Route {
-  @service('breadcrumbs') breadcrumbsService;
-
   model() {
     return Math.random();
   }

--- a/tests/integration/helpers/breadcrumbs-test.js
+++ b/tests/integration/helpers/breadcrumbs-test.js
@@ -13,7 +13,10 @@ module('Integration | Helper | breadcrumbs', function (hooks) {
       @tracked items = [];
     }
 
-    this.owner.register('service:breadcrumbs', MockBreadcrumbsService);
+    this.owner.register(
+      'service:ember-breadcrumb-trail@breadcrumbs',
+      MockBreadcrumbsService
+    );
 
     await render(hbs`
       <ol>
@@ -25,7 +28,9 @@ module('Integration | Helper | breadcrumbs', function (hooks) {
 
     assert.dom('[data-test-breadcrumb-item]').doesNotExist();
 
-    let breadcrumbsService = this.owner.lookup('service:breadcrumbs');
+    let breadcrumbsService = this.owner.lookup(
+      'service:ember-breadcrumb-trail@breadcrumbs'
+    );
     breadcrumbsService.items = [
       {
         title: 'foo',

--- a/tests/unit/services/breadcrumbs-test.js
+++ b/tests/unit/services/breadcrumbs-test.js
@@ -6,13 +6,17 @@ module('Unit | Service | breadcrumbs', function (hooks) {
   setupTest(hooks);
 
   test("it doesn't contain any breadcrumbs by default", async function (assert) {
-    let breadcrumbsService = this.owner.lookup('service:breadcrumbs');
+    let breadcrumbsService = this.owner.lookup(
+      'service:ember-breadcrumb-trail@breadcrumbs'
+    );
 
     assert.equal(breadcrumbsService.items.length, 0);
   });
 
   test("it's possible to add new breadcrumbs with the addBreadcrumb method", async function (assert) {
-    let breadcrumbsService = this.owner.lookup('service:breadcrumbs');
+    let breadcrumbsService = this.owner.lookup(
+      'service:ember-breadcrumb-trail@breadcrumbs'
+    );
 
     breadcrumbsService.addBreadcrumb({
       title: 'foo',
@@ -32,7 +36,9 @@ module('Unit | Service | breadcrumbs', function (hooks) {
   });
 
   test('it returns a unique id when adding a breadcrumb', async function (assert) {
-    let breadcrumbsService = this.owner.lookup('service:breadcrumbs');
+    let breadcrumbsService = this.owner.lookup(
+      'service:ember-breadcrumb-trail@breadcrumbs'
+    );
 
     let firstId = breadcrumbsService.addBreadcrumb({
       title: 'foo',
@@ -49,7 +55,9 @@ module('Unit | Service | breadcrumbs', function (hooks) {
   });
 
   test("it's possible to update breadcrumbs with the updateBreadcrumb method", async function (assert) {
-    let breadcrumbsService = this.owner.lookup('service:breadcrumbs');
+    let breadcrumbsService = this.owner.lookup(
+      'service:ember-breadcrumb-trail@breadcrumbs'
+    );
 
     let firstId = breadcrumbsService.addBreadcrumb({
       title: 'foo',
@@ -72,7 +80,9 @@ module('Unit | Service | breadcrumbs', function (hooks) {
   });
 
   test("it's possible to remove breadcrumbs with the removeBreadcrumb method", async function (assert) {
-    let breadcrumbsService = this.owner.lookup('service:breadcrumbs');
+    let breadcrumbsService = this.owner.lookup(
+      'service:ember-breadcrumb-trail@breadcrumbs'
+    );
 
     let firstId = breadcrumbsService.addBreadcrumb({
       title: 'foo',


### PR DESCRIPTION
This allows us to remove the breadcrumbs service app reexport. Since the service is considered a private API, not exporting it seems like a good idea.