### PR TITLE
Add dynamic segments example

### DIFF
--- a/tests/acceptance/dynamic-segments-test.js
+++ b/tests/acceptance/dynamic-segments-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+
+module('Acceptance | dynamic segments', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('redirecting to a parent route from a child of a route with dynamic segments works properly', async function (assert) {
+    await visit('/foo/1234/baz');
+    assert.dom('[data-test-breadcrumb]').exists({ count: 4 });
+
+    await visit('/foo');
+    assert.dom('[data-test-breadcrumb]').exists({ count: 2 });
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,7 +8,7 @@ export default class Router extends EmberRouter {
 
 Router.map(function () {
   this.route('foo', function () {
-    this.route('bar', function () {
+    this.route('bar', { path: '/:id' }, function () {
       this.route('baz');
     });
   });

--- a/tests/dummy/app/routes/foo/bar.js
+++ b/tests/dummy/app/routes/foo/bar.js
@@ -1,3 +1,7 @@
 import Route from '@ember/routing/route';
 
-export default class FooBarRoute extends Route {}
+export default class FooBarRoute extends Route {
+  model({ id }) {
+    return { id };
+  }
+}

--- a/tests/dummy/app/routes/foo/bar/baz.js
+++ b/tests/dummy/app/routes/foo/bar/baz.js
@@ -1,10 +1,10 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 
 export default class FooBarBazRoute extends Route {
-  @service('breadcrumbs') breadcrumbsService;
-
   model() {
-    return Math.random();
+    return {
+      randomNumber: Math.random(),
+      id: this.paramsFor('foo.bar').id,
+    };
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -10,27 +10,33 @@
       <LinkTo @route="foo">Foo</LinkTo>
     </li>
     <li>
-      <LinkTo @route="foo.bar">Bar</LinkTo>
+      <LinkTo @route="foo.bar" @model={{12345}}>Bar</LinkTo>
     </li>
     <li>
-      <LinkTo @route="foo.bar.baz">Baz</LinkTo>
+      <LinkTo @route="foo.bar.baz" @model={{12345}}>Baz</LinkTo>
     </li>
   </ol>
 </nav>
 
 <nav aria-label="breadcrumbs">
   <ol>
-    {{#each (breadcrumbs) as |breadcrumb|}}
-      <li>
-        {{#if breadcrumb.data.route}}
+    {{#each (breadcrumbs) as |breadcrumb index|}}
+      <li data-test-breadcrumb={{index}}>
+        {{#if breadcrumb.data.model}}
+          <LinkTo
+            @route={{breadcrumb.data.route}}
+            @model={{breadcrumb.data.model}}
+            aria-current={{if (is-last breadcrumb (breadcrumbs)) "page"}}
+          >
+            {{breadcrumb.title}}
+          </LinkTo>
+        {{else}}
           <LinkTo
             @route={{breadcrumb.data.route}}
             aria-current={{if (is-last breadcrumb (breadcrumbs)) "page"}}
           >
             {{breadcrumb.title}}
           </LinkTo>
-        {{else}}
-          {{breadcrumb.title}}
         {{/if}}
       </li>
     {{/each}}

--- a/tests/dummy/app/templates/foo/bar.hbs
+++ b/tests/dummy/app/templates/foo/bar.hbs
@@ -1,5 +1,5 @@
 {{page-title "Bar"}}
-{{breadcrumb "Bar: " this.number route="foo.bar"}}
+{{breadcrumb "Bar: " this.number route="foo.bar" model=this.model.id}}
 {{outlet}}
 
 <button type="button" {{on "click" this.getRandomNumber}}>Random</button>

--- a/tests/dummy/app/templates/foo/bar/baz.hbs
+++ b/tests/dummy/app/templates/foo/bar/baz.hbs
@@ -1,3 +1,7 @@
 {{page-title "Baz"}}
-{{breadcrumb "Baz: " this.model route="foo.bar.baz"}}
+{{breadcrumb
+  "Baz: " this.model.randomNumber
+  route="foo.bar.baz"
+  model=this.model.id
+}}
 {{outlet}}


### PR DESCRIPTION
It seems that passing the model of the parent with a dynamic segment is required for all breadcrumbs on child routes.