### PR TITLE
Replace `inject` imports with `service`

### DIFF
--- a/addon/src/helpers/breadcrumb.ts
+++ b/addon/src/helpers/breadcrumb.ts
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type { BreadcrumbData } from '../private-types.ts';
 import type BreadcrumbsService from '../services/breadcrumbs.ts';
 

--- a/addon/src/helpers/breadcrumbs.ts
+++ b/addon/src/helpers/breadcrumbs.ts
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import type { BreadcrumbData } from '../private-types.ts';
 import type BreadcrumbsService from '../services/breadcrumbs.ts';
 

--- a/test-app/app/routes/foo/bar/baz.js
+++ b/test-app/app/routes/foo/bar/baz.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FooBarBazRoute extends Route {
   @service('breadcrumbs') breadcrumbsService;


### PR DESCRIPTION
Fixes deprecation https://deprecations.emberjs.com/id/importing-inject-from-ember-service/